### PR TITLE
Move CPU builds from Travis

### DIFF
--- a/common/install_travis_python.sh
+++ b/common/install_travis_python.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -ex
+
+# Use pyenv to install a specific version of Python
+if [[ "$BUILD" == *py2.7* ]]; then
+  export PYTHON_VERSION=2.7
+fi
+
+if [[ "$BUILD" == *py2.7.9* ]]; then
+  export PYTHON_VERSION=2.7.9
+fi
+
+if [[ "$BUILD" == *py3.5* ]]; then
+  export PYTHON_VERSION=3.5
+fi
+
+if [[ "$BUILD" == *py3.6* ]]; then
+  export PYTHON_VERSION=3.6
+fi
+
+if [[ "$BUILD" == *pynightly* ]]; then
+  export PYTHON_VERSION=nightly
+fi
+
+# Download Python binary from Travis
+wget https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/14.04/x86_64/python-$PYTHON_VERSION.tar.bz2
+tar xjf python-$PYTHON_VERSION.tar.bz2 --directory /
+export PATH=/opt/python/$PYTHON_VERSION/bin:$PATH
+export LD_LIBRARY_PATH=/opt/python/$PYTHON_VERSION/lib:$LD_LIBRARY_PATH
+
+apt-get update
+apt-get install -y gfortran
+
+# Install pip packages
+pip install --upgrade pip
+
+pip install \
+    numpy \
+    future \
+    hypothesis \
+    protobuf \
+    pytest \
+    pyyaml
+
+# MKL library from pip does not support Python 2.7.9
+if [[ "$BUILD" != *py2.7.9* ]]; then
+    pip install mkl
+fi
+
+# SciPy does not support Python 3.7
+if [[ "$BUILD" != *pynightly* ]]; then
+    pip install scipy==0.19.1 scikit-image
+fi

--- a/pytorch-linux-trusty-py2.7.9/Dockerfile
+++ b/pytorch-linux-trusty-py2.7.9/Dockerfile
@@ -1,0 +1,13 @@
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
+
+# Install Python stuff
+ARG BUILD
+ADD ./common/install_travis_python.sh install_travis_python.sh
+RUN bash ./install_travis_python.sh && rm install_travis_python.sh
+
+# Install user
+ADD ./common/install_user.sh install_user.sh
+RUN bash ./install_user.sh && rm install_user.sh
+
+CMD ["bash"]

--- a/pytorch-linux-trusty-py2.7/Dockerfile
+++ b/pytorch-linux-trusty-py2.7/Dockerfile
@@ -1,0 +1,13 @@
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
+
+# Install Python stuff
+ARG BUILD
+ADD ./common/install_travis_python.sh install_travis_python.sh
+RUN bash ./install_travis_python.sh && rm install_travis_python.sh
+
+# Install user
+ADD ./common/install_user.sh install_user.sh
+RUN bash ./install_user.sh && rm install_user.sh
+
+CMD ["bash"]

--- a/pytorch-linux-trusty-py3.5/Dockerfile
+++ b/pytorch-linux-trusty-py3.5/Dockerfile
@@ -1,0 +1,13 @@
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
+
+# Install Python stuff
+ARG BUILD
+ADD ./common/install_travis_python.sh install_travis_python.sh
+RUN bash ./install_travis_python.sh && rm install_travis_python.sh
+
+# Install user
+ADD ./common/install_user.sh install_user.sh
+RUN bash ./install_user.sh && rm install_user.sh
+
+CMD ["bash"]

--- a/pytorch-linux-trusty-py3.6/Dockerfile
+++ b/pytorch-linux-trusty-py3.6/Dockerfile
@@ -1,0 +1,13 @@
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
+
+# Install Python stuff
+ARG BUILD
+ADD ./common/install_travis_python.sh install_travis_python.sh
+RUN bash ./install_travis_python.sh && rm install_travis_python.sh
+
+# Install user
+ADD ./common/install_user.sh install_user.sh
+RUN bash ./install_user.sh && rm install_user.sh
+
+CMD ["bash"]

--- a/pytorch-linux-trusty-pynightly/Dockerfile
+++ b/pytorch-linux-trusty-pynightly/Dockerfile
@@ -1,0 +1,13 @@
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
+
+# Install Python stuff
+ARG BUILD
+ADD ./common/install_travis_python.sh install_travis_python.sh
+RUN bash ./install_travis_python.sh && rm install_travis_python.sh
+
+# Install user
+ADD ./common/install_user.sh install_user.sh
+RUN bash ./install_user.sh && rm install_user.sh
+
+CMD ["bash"]

--- a/pytorch-linux-trusty/Dockerfile
+++ b/pytorch-linux-trusty/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:trusty
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install common dependencies (so that this step can be cached separately)
+ADD ./common/install_base.sh install_base.sh
+RUN bash ./install_base.sh && rm install_base.sh
+
+CMD ["bash"]


### PR DESCRIPTION
These are the Docker environments for PyTorch's CPU builds. 

Locally both `tools/run_aten_tests.sh` and `test/run_test.sh` in PyTorch passed when using any of these as environment.