### PR TITLE
Revert "Merge build phases for CPU builds"

### DIFF
--- a/pytorch-linux-trusty-py2.7.9/Dockerfile
+++ b/pytorch-linux-trusty-py2.7.9/Dockerfile
@@ -1,10 +1,5 @@
-FROM ubuntu:trusty
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Install common dependencies (so that this step can be cached separately)
-ADD ./common/install_base.sh install_base.sh
-RUN bash ./install_base.sh && rm install_base.sh
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
 
 # Install Python stuff
 ARG BUILD

--- a/pytorch-linux-trusty-py2.7/Dockerfile
+++ b/pytorch-linux-trusty-py2.7/Dockerfile
@@ -1,10 +1,5 @@
-FROM ubuntu:trusty
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Install common dependencies (so that this step can be cached separately)
-ADD ./common/install_base.sh install_base.sh
-RUN bash ./install_base.sh && rm install_base.sh
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
 
 # Install Python stuff
 ARG BUILD

--- a/pytorch-linux-trusty-py3.5/Dockerfile
+++ b/pytorch-linux-trusty-py3.5/Dockerfile
@@ -1,10 +1,5 @@
-FROM ubuntu:trusty
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Install common dependencies (so that this step can be cached separately)
-ADD ./common/install_base.sh install_base.sh
-RUN bash ./install_base.sh && rm install_base.sh
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
 
 # Install Python stuff
 ARG BUILD

--- a/pytorch-linux-trusty-py3.6/Dockerfile
+++ b/pytorch-linux-trusty-py3.6/Dockerfile
@@ -1,10 +1,5 @@
-FROM ubuntu:trusty
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Install common dependencies (so that this step can be cached separately)
-ADD ./common/install_base.sh install_base.sh
-RUN bash ./install_base.sh && rm install_base.sh
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
 
 # Install Python stuff
 ARG BUILD

--- a/pytorch-linux-trusty-pynightly/Dockerfile
+++ b/pytorch-linux-trusty-pynightly/Dockerfile
@@ -1,10 +1,5 @@
-FROM ubuntu:trusty
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Install common dependencies (so that this step can be cached separately)
-ADD ./common/install_base.sh install_base.sh
-RUN bash ./install_base.sh && rm install_base.sh
+ARG BUILD_ID
+FROM ci.pytorch.org/pytorch/pytorch-linux-trusty:${BUILD_ID}
 
 # Install Python stuff
 ARG BUILD

--- a/pytorch-linux-trusty/Dockerfile
+++ b/pytorch-linux-trusty/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:trusty
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install common dependencies (so that this step can be cached separately)
+ADD ./common/install_base.sh install_base.sh
+RUN bash ./install_base.sh && rm install_base.sh
+
+CMD ["bash"]


### PR DESCRIPTION
Earlier there was a misunderstanding on how we should merge different stages for the CPU builds. Reverting commit 2f54e29629389f55b00b54640e13755ad2f8be3a so that we stick with the original design.