### PR TITLE
Add rwx permission for jenkins to Python directory

### DIFF
--- a/common/install_travis_python.sh
+++ b/common/install_travis_python.sh
@@ -29,6 +29,9 @@ tar xjf python-$PYTHON_VERSION.tar.bz2 --directory /
 export PATH=/opt/python/$PYTHON_VERSION/bin:$PATH
 export LD_LIBRARY_PATH=/opt/python/$PYTHON_VERSION/lib:$LD_LIBRARY_PATH
 
+chown -R jenkins:jenkins /opt/python/$PYTHON_VERSION/
+chmod -R u=rwx /opt/python/$PYTHON_VERSION/
+
 apt-get update
 apt-get install -y gfortran
 

--- a/common/install_travis_python.sh
+++ b/common/install_travis_python.sh
@@ -2,7 +2,6 @@
 
 set -ex
 
-# Use pyenv to install a specific version of Python
 if [[ "$BUILD" == *py2.7* ]]; then
   export PYTHON_VERSION=2.7
 fi
@@ -28,9 +27,6 @@ wget https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/14.04/x86_6
 tar xjf python-$PYTHON_VERSION.tar.bz2 --directory /
 export PATH=/opt/python/$PYTHON_VERSION/bin:$PATH
 export LD_LIBRARY_PATH=/opt/python/$PYTHON_VERSION/lib:$LD_LIBRARY_PATH
-
-chown -R jenkins:jenkins /opt/python/$PYTHON_VERSION/
-chmod -R u=rwx /opt/python/$PYTHON_VERSION/
 
 apt-get update
 apt-get install -y gfortran

--- a/common/install_user.sh
+++ b/common/install_user.sh
@@ -2,6 +2,26 @@
 
 set -ex
 
+if [[ "$BUILD" == *py2.7* ]]; then
+  export PYTHON_VERSION=2.7
+fi
+
+if [[ "$BUILD" == *py2.7.9* ]]; then
+  export PYTHON_VERSION=2.7.9
+fi
+
+if [[ "$BUILD" == *py3.5* ]]; then
+  export PYTHON_VERSION=3.5
+fi
+
+if [[ "$BUILD" == *py3.6* ]]; then
+  export PYTHON_VERSION=3.6
+fi
+
+if [[ "$BUILD" == *pynightly* ]]; then
+  export PYTHON_VERSION=nightly
+fi
+
 # Mirror jenkins user in container
 echo "jenkins:x:1001:1001::/var/lib/jenkins:" >> /etc/passwd
 echo "jenkins:x:1001:" >> /etc/group
@@ -12,6 +32,10 @@ chown jenkins:jenkins /var/lib/jenkins
 
 # Allow writing to /usr/local (for make install)
 chown jenkins:jenkins /usr/local
+
+# Allow writing to /opt/python/$PYTHON_VERSION/ (for adding Python package in CPU builds)
+chown -R jenkins:jenkins /opt/python/$PYTHON_VERSION/
+chmod -R u=rwx /opt/python/$PYTHON_VERSION/
 
 # Allow sudo
 echo 'jenkins ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jenkins


### PR DESCRIPTION
This allows the `jenkins` user to add pytorch package to `/opt/python/$PYTHON_VERSION/`.