### PR TITLE
handle python directory not exist case

### DIFF
--- a/common/install_user.sh
+++ b/common/install_user.sh
@@ -34,10 +34,10 @@ chown jenkins:jenkins /var/lib/jenkins
 chown jenkins:jenkins /usr/local
 
 # Allow writing to /opt/python/$PYTHON_VERSION/ (for adding Python package in CPU builds)
-export PYTHON_PATH=/opt/python/$PYTHON_VERSION/
-if [ -d "$PYTHON_PATH" ]; then
-  chown -R jenkins:jenkins $PYTHON_PATH
-  chmod -R u=rwx $PYTHON_PATH
+export OPT_PYTHON_PATH=/opt/python/$PYTHON_VERSION/
+if [ -d "$OPT_PYTHON_PATH" ]; then
+  chown -R jenkins:jenkins $OPT_PYTHON_PATH
+  chmod -R u=rwx $OPT_PYTHON_PATH
 fi
 
 # Allow sudo

--- a/common/install_user.sh
+++ b/common/install_user.sh
@@ -34,8 +34,11 @@ chown jenkins:jenkins /var/lib/jenkins
 chown jenkins:jenkins /usr/local
 
 # Allow writing to /opt/python/$PYTHON_VERSION/ (for adding Python package in CPU builds)
-chown -R jenkins:jenkins /opt/python/$PYTHON_VERSION/
-chmod -R u=rwx /opt/python/$PYTHON_VERSION/
+export PYTHON_PATH=/opt/python/$PYTHON_VERSION/
+if [ -d "$PYTHON_PATH" ]; then
+  chown -R jenkins:jenkins $PYTHON_PATH
+  chmod -R u=rwx $PYTHON_PATH
+fi
 
 # Allow sudo
 echo 'jenkins ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/jenkins


### PR DESCRIPTION
`chown` and `chmod` give hard failure when the directory doesn't exist. This diff checks its existence before using the commands.