### PR TITLE
Install ninja-build with apt-get

### DIFF
--- a/common/install_base.sh
+++ b/common/install_base.sh
@@ -27,6 +27,7 @@ apt-get install -y --no-install-recommends \
   libpthread-stubs0-dev \
   libsnappy-dev \
   libyaml-dev \
+  ninja-build \
   protobuf-compiler \
   python \
   python-dev \


### PR DESCRIPTION
@ezyang @zdevito

A braindump of how I got here:

## Why do we need ninja

First, let me say that there are two `ninja` *things*:
1. `ninja`, the command line tool and build system,
2. `ninja`, the Python module that exposes a tiny module to emit ninja build files. 

The PyTorch CI currently requires neither, however the [new C++ extensions](https://github.com/pytorch/pytorch/pull/4842) do require *the command line tool* (but __not the Python module__).

## Why can't we `pip install ninja`?

It is currently very hard to install `ninja` with `pip`, as there is a [bug in setuptools](https://github.com/pypa/setuptools/issues/937), that manifests itself like this:

```
pip install ninja
Downloading/unpacking ninja
  Downloading ninja-1.7.2.post2.tar.gz (295kB): 295kB downloaded
  Running setup.py (path:/tmp/pip_build_root/ninja/setup.py) egg_info for package ninja
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip_build_root/ninja/setup.py", line 7, in <module>
        from skbuild import setup
    ImportError: No module named skbuild
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip_build_root/ninja/setup.py", line 7, in <module>

    from skbuild import setup

ImportError: No module named skbuild
```

*Sometimes*, this can be solved by upgrading pip (`pip install --upgrade pip`) -- but not always (e.g. does not fix the problem on nightly Python). I have spent many hours trying to work around this.

## The solution

The best solution IMO is to simply install `ninja` with apt directly, then there need be no `pip` issues. 

This will *not* interfere with the rest of the build, since the `ninja` Python module is not installed by apt, so Pytorch's `setup.py` will not pick it up and still build with cmake. However `ninja` will be available as a command-line tool, so that the C++ extensions can be built.