### PR TITLE
Install libc6-dbg

### DIFF
--- a/common/install_base.sh
+++ b/common/install_base.sh
@@ -34,6 +34,7 @@ apt-get install -y --no-install-recommends \
   curl \
   git \
   libatlas-base-dev \
+  libc6-dbg \
   libiomp-dev \
   libyaml-dev \
   libz-dev \


### PR DESCRIPTION
Valgrind is relied on this package to show debug info. Since we are not using apt-get install to install valrgind anymore, libc6-dbg wont be installed by default. 
Therefore we need to install it manually.