### PR TITLE
Add install options for Caffe2 builds and tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -150,6 +150,9 @@ tmp_tag="tmp-$(cat /dev/urandom | tr -dc 'a-z' | fold -w 32 | head -n 1)"
 docker build \
        --no-cache \
        --build-arg "BUILD_ENVIRONMENT=${image}" \
+       --build-arg "PROTOBUF=${PROTOBUF:-}" \
+       --build-arg "DB=${DB:-}" \
+       --build-arg "VISION=${VISION:-}" \
        --build-arg "EC2=${EC2:-}" \
        --build-arg "JENKINS=${JENKINS:-}" \
        --build-arg "JENKINS_UID=${JENKINS_UID:-}" \

--- a/build.sh
+++ b/build.sh
@@ -32,70 +32,109 @@ case "$image" in
   pytorch-linux-trusty-py2.7.9)
     TRAVIS_PYTHON_VERSION=2.7.9
     GCC_VERSION=7
+    # Do not install PROTOBUF, DB, and VISION as a test
     ;;
   pytorch-linux-trusty-py2.7)
     TRAVIS_PYTHON_VERSION=2.7
     GCC_VERSION=7
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-trusty-py3.5)
     TRAVIS_PYTHON_VERSION=3.5
     GCC_VERSION=7
+    # Do not install PROTOBUF, DB, and VISION as a test
     ;;
   pytorch-linux-trusty-py3.6-gcc4.8)
     ANACONDA_PYTHON_VERSION=3.6
     GCC_VERSION=4.8
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-trusty-py3.6-gcc5.4)
     ANACONDA_PYTHON_VERSION=3.6
     GCC_VERSION=5
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-trusty-py3.6-gcc7.2)
     ANACONDA_PYTHON_VERSION=3.6
     GCC_VERSION=7
+    # Do not install PROTOBUF, DB, and VISION as a test
     ;;
   pytorch-linux-trusty-py3.6-gcc7)
     ANACONDA_PYTHON_VERSION=3.6
     GCC_VERSION=7
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-trusty-pynightly)
     TRAVIS_PYTHON_VERSION=nightly
     GCC_VERSION=7
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-xenial-cuda8-cudnn6-py2)
     CUDA_VERSION=8.0
     CUDNN_VERSION=6
     ANACONDA_PYTHON_VERSION=2.7
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-xenial-cuda8-cudnn6-py3)
     CUDA_VERSION=8.0
     CUDNN_VERSION=6
     ANACONDA_PYTHON_VERSION=3.6
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-xenial-cuda9-cudnn7-py2)
     CUDA_VERSION=9.0
     CUDNN_VERSION=7
     ANACONDA_PYTHON_VERSION=2.7
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-xenial-cuda9-cudnn7-py3)
     CUDA_VERSION=9.0
     CUDNN_VERSION=7
     ANACONDA_PYTHON_VERSION=3.6
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-xenial-cuda9.2-cudnn7-py3-gcc7)
     CUDA_VERSION=9.2
     CUDNN_VERSION=7
     ANACONDA_PYTHON_VERSION=3.6
     GCC_VERSION=7
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-xenial-cuda10-cudnn7-py3-gcc7)
     CUDA_VERSION=10.0
     CUDNN_VERSION=7
     ANACONDA_PYTHON_VERSION=3.6
     GCC_VERSION=7
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
   pytorch-linux-xenial-py3-clang5-asan)
     ANACONDA_PYTHON_VERSION=3.6
     CLANG_VERSION=5.0
+    PROTOBUF=yes
+    DB=yes
+    VISION=yes
     ;;
 esac
 

--- a/common/install_android.sh
+++ b/common/install_android.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -ex
+
+apt-get update
+apt-get install -y --no-install-recommends autotools-dev autoconf unzip
+apt-get autoclean && apt-get clean
+rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+pushd /tmp
+curl -Os https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
+popd
+_ndk_dir=/opt/ndk
+mkdir -p "$_ndk_dir"
+unzip -qo /tmp/android*.zip -d "$_ndk_dir"
+_versioned_dir=$(find "$_ndk_dir/" -mindepth 1 -maxdepth 1 -type d)
+mv "$_versioned_dir"/* "$_ndk_dir"/
+rmdir "$_versioned_dir"
+rm -rf /tmp/*

--- a/common/install_db.sh
+++ b/common/install_db.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -ex
+
+# This function installs protobuf 2.6
+install_protobuf_26() {
+  pb_dir="/usr/temp_pb_install_dir"
+  mkdir -p $pb_dir
+
+  # On the nvidia/cuda:9-cudnn7-devel-centos7 image we need this symlink or
+  # else it will fail with
+  #   g++: error: ./../lib64/crti.o: No such file or directory
+  ln -s /usr/lib64 "$pb_dir/lib64"
+
+  curl -LO "https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz"
+  tar -xvz -C "$pb_dir" --strip-components 1 -f protobuf-2.6.1.tar.gz
+  pushd "$pb_dir" && ./configure && make && make check && sudo make install && sudo ldconfig
+  popd
+  rm -rf $pb_dir
+}
+
+install_ubuntu() {
+  # Use AWS mirror if running in EC2
+  if [ -n "${EC2:-}" ]; then
+    A="archive.ubuntu.com"
+    B="us-east-1.ec2.archive.ubuntu.com"
+    perl -pi -e "s/${A}/${B}/g" /etc/apt/sources.list
+  fi
+
+  apt-get update
+  apt-get install -y --no-install-recommends \
+          libhiredis-dev \
+          libleveldb-dev \
+          liblmdb-dev \
+          libsnappy-dev
+
+  # Cleanup
+  apt-get autoclean && apt-get clean
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+}
+
+install_centos() {
+  # Need EPEL for many packages we depend on.
+  # See http://fedoraproject.org/wiki/EPEL
+  yum --enablerepo=extras install -y epel-release
+
+  yum install -y \
+      hiredis-devel \
+      leveldb-devel \
+      lmdb-devel \
+      snappy-devel
+
+  # Cleanup
+  yum clean all
+  rm -rf /var/cache/yum
+  rm -rf /var/lib/yum/yumdb
+  rm -rf /var/lib/yum/history
+}
+
+# Install base packages depending on the base OS
+if [ -f /etc/lsb-release ]; then
+  install_ubuntu
+elif [ -f /etc/os-release ]; then
+  install_centos
+else
+  echo "Unable to determine OS..."
+  exit 1
+fi

--- a/common/install_protobuf.sh
+++ b/common/install_protobuf.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -ex
+
+# This function installs protobuf 2.6
+install_protobuf_26() {
+  pb_dir="/usr/temp_pb_install_dir"
+  mkdir -p $pb_dir
+
+  # On the nvidia/cuda:9-cudnn7-devel-centos7 image we need this symlink or
+  # else it will fail with
+  #   g++: error: ./../lib64/crti.o: No such file or directory
+  ln -s /usr/lib64 "$pb_dir/lib64"
+
+  curl -LO "https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz"
+  tar -xvz -C "$pb_dir" --strip-components 1 -f protobuf-2.6.1.tar.gz
+  pushd "$pb_dir" && ./configure && make && make check && sudo make install && sudo ldconfig
+  popd
+  rm -rf $pb_dir
+}
+
+install_ubuntu() {
+  # Use AWS mirror if running in EC2
+  if [ -n "${EC2:-}" ]; then
+    A="archive.ubuntu.com"
+    B="us-east-1.ec2.archive.ubuntu.com"
+    perl -pi -e "s/${A}/${B}/g" /etc/apt/sources.list
+  fi
+
+  # Ubuntu 14.04 ships with protobuf 2.5, but ONNX needs protobuf >= 2.6
+  # so we install that here if on 14.04
+  # Ubuntu 14.04 also has cmake 2.8.12 as the default option, so we will
+  # install cmake3 here and use cmake3.
+  if [[ "$UBUNTU_VERSION" == 14.04 ]]; then
+    apt-get install -y --no-install-recommends cmake3
+    install_protobuf_26
+  else
+    apt-get install -y --no-install-recommends \
+            libprotobuf-dev \
+            protobuf-compiler
+  fi
+
+  # Cleanup
+  apt-get autoclean && apt-get clean
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+}
+
+install_centos() {
+  # Centos7 ships with protobuf 2.5, but ONNX needs protobuf >= 2.6
+  # so we always install install that here
+  install_protobuf_26
+}
+
+# Install base packages depending on the base OS
+if [ -f /etc/lsb-release ]; then
+  install_ubuntu
+elif [ -f /etc/os-release ]; then
+  install_centos
+else
+  echo "Unable to determine OS..."
+  exit 1
+fi

--- a/common/install_vision.sh
+++ b/common/install_vision.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -ex
+
+# This function installs protobuf 2.6
+install_protobuf_26() {
+  pb_dir="/usr/temp_pb_install_dir"
+  mkdir -p $pb_dir
+
+  # On the nvidia/cuda:9-cudnn7-devel-centos7 image we need this symlink or
+  # else it will fail with
+  #   g++: error: ./../lib64/crti.o: No such file or directory
+  ln -s /usr/lib64 "$pb_dir/lib64"
+
+  curl -LO "https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.gz"
+  tar -xvz -C "$pb_dir" --strip-components 1 -f protobuf-2.6.1.tar.gz
+  pushd "$pb_dir" && ./configure && make && make check && sudo make install && sudo ldconfig
+  popd
+  rm -rf $pb_dir
+}
+
+install_ubuntu() {
+  # Use AWS mirror if running in EC2
+  if [ -n "${EC2:-}" ]; then
+    A="archive.ubuntu.com"
+    B="us-east-1.ec2.archive.ubuntu.com"
+    perl -pi -e "s/${A}/${B}/g" /etc/apt/sources.list
+  fi
+
+  apt-get update
+  apt-get install -y --no-install-recommends \
+          libopencv-dev \
+          libavcodec-dev
+
+  # Cleanup
+  apt-get autoclean && apt-get clean
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+}
+
+install_centos() {
+  # Need EPEL for many packages we depend on.
+  # See http://fedoraproject.org/wiki/EPEL
+  yum --enablerepo=extras install -y epel-release
+
+  yum install -y \
+      opencv-devel \
+      ffmpeg-devel
+
+  # Cleanup
+  yum clean all
+  rm -rf /var/cache/yum
+  rm -rf /var/lib/yum/yumdb
+  rm -rf /var/lib/yum/history
+}
+
+# Install base packages depending on the base OS
+if [ -f /etc/lsb-release ]; then
+  install_ubuntu
+elif [ -f /etc/os-release ]; then
+  install_centos
+else
+  echo "Unable to determine OS..."
+  exit 1
+fi

--- a/ubuntu-cuda/Dockerfile
+++ b/ubuntu-cuda/Dockerfile
@@ -41,24 +41,28 @@ ARG PROTOBUF
 ADD ./common/install_protobuf.sh install_protobuf.sh
 RUN if [ -n "${PROTOBUF}" ]; then bash ./install_protobuf.sh; fi
 RUN rm install_protobuf.sh
+ENV INSTALLED_PROTOBUF ${PROTOBUF}
 
 # (optional) Install database packages like LMDB and LevelDB
 ARG DB
 ADD ./common/install_db.sh install_db.sh
 RUN if [ -n "${DB}" ]; then bash ./install_db.sh; fi
 RUN rm install_db.sh
+ENV INSTALLED_DB ${DB}
 
 # (optional) Install vision packages like OpenCV and ffmpeg
 ARG VISION
 ADD ./common/install_vision.sh install_vision.sh
 RUN if [ -n "${VISION}" ]; then bash ./install_vision.sh; fi
 RUN rm install_vision.sh
+ENV INSTALLED_VISION ${VISION}
 
 # (optional) Install Android NDK
 ARG ANDROID
 ADD ./common/install_android.sh install_android.sh
 RUN if [ -n "${ANDROID}" ]; then bash ./install_android.sh; fi
 RUN rm install_android.sh
+ENV INSTALLED_ANDROID ${ANDROID}
 
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ADD ./common/install_cache.sh install_cache.sh

--- a/ubuntu-cuda/Dockerfile
+++ b/ubuntu-cuda/Dockerfile
@@ -36,6 +36,30 @@ ENV PATH /opt/python/$TRAVIS_PYTHON_VERSION/bin:$PATH
 ADD ./common/install_travis_python.sh install_travis_python.sh
 RUN bash ./install_travis_python.sh && rm install_travis_python.sh
 
+# (optional) Install protobuf for ONNX
+ARG PROTOBUF
+ADD ./common/install_protobuf.sh install_protobuf.sh
+RUN if [ -n "${PROTOBUF}" ]; then bash ./install_protobuf.sh; fi
+RUN rm install_protobuf.sh
+
+# (optional) Install database packages like LMDB and LevelDB
+ARG DB
+ADD ./common/install_db.sh install_db.sh
+RUN if [ -n "${DB}" ]; then bash ./install_db.sh; fi
+RUN rm install_db.sh
+
+# (optional) Install vision packages like OpenCV and ffmpeg
+ARG VISION
+ADD ./common/install_vision.sh install_vision.sh
+RUN if [ -n "${VISION}" ]; then bash ./install_vision.sh; fi
+RUN rm install_vision.sh
+
+# (optional) Install Android NDK
+ARG ANDROID
+ADD ./common/install_android.sh install_android.sh
+RUN if [ -n "${ANDROID}" ]; then bash ./install_android.sh; fi
+RUN rm install_android.sh
+
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ADD ./common/install_cache.sh install_cache.sh
 ENV PATH /opt/cache/bin:$PATH

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -37,6 +37,30 @@ ENV PATH /opt/python/$TRAVIS_PYTHON_VERSION/bin:$PATH
 ADD ./common/install_travis_python.sh install_travis_python.sh
 RUN bash ./install_travis_python.sh && rm install_travis_python.sh
 
+# (optional) Install protobuf for ONNX
+ARG PROTOBUF
+ADD ./common/install_protobuf.sh install_protobuf.sh
+RUN if [ -n "${PROTOBUF}" ]; then bash ./install_protobuf.sh; fi
+RUN rm install_protobuf.sh
+
+# (optional) Install database packages like LMDB and LevelDB
+ARG DB
+ADD ./common/install_db.sh install_db.sh
+RUN if [ -n "${DB}" ]; then bash ./install_db.sh; fi
+RUN rm install_db.sh
+
+# (optional) Install vision packages like OpenCV and ffmpeg
+ARG VISION
+ADD ./common/install_vision.sh install_vision.sh
+RUN if [ -n "${VISION}" ]; then bash ./install_vision.sh; fi
+RUN rm install_vision.sh
+
+# (optional) Install Android NDK
+ARG ANDROID
+ADD ./common/install_android.sh install_android.sh
+RUN if [ -n "${ANDROID}" ]; then bash ./install_android.sh; fi
+RUN rm install_android.sh
+
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ADD ./common/install_cache.sh install_cache.sh
 ENV PATH /opt/cache/bin:$PATH

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -42,24 +42,28 @@ ARG PROTOBUF
 ADD ./common/install_protobuf.sh install_protobuf.sh
 RUN if [ -n "${PROTOBUF}" ]; then bash ./install_protobuf.sh; fi
 RUN rm install_protobuf.sh
+ENV INSTALLED_PROTOBUF ${PROTOBUF}
 
 # (optional) Install database packages like LMDB and LevelDB
 ARG DB
 ADD ./common/install_db.sh install_db.sh
 RUN if [ -n "${DB}" ]; then bash ./install_db.sh; fi
 RUN rm install_db.sh
+ENV INSTALLED_DB ${DB}
 
 # (optional) Install vision packages like OpenCV and ffmpeg
 ARG VISION
 ADD ./common/install_vision.sh install_vision.sh
 RUN if [ -n "${VISION}" ]; then bash ./install_vision.sh; fi
 RUN rm install_vision.sh
+ENV INSTALLED_VISION ${VISION}
 
 # (optional) Install Android NDK
 ARG ANDROID
 ADD ./common/install_android.sh install_android.sh
 RUN if [ -n "${ANDROID}" ]; then bash ./install_android.sh; fi
 RUN rm install_android.sh
+ENV INSTALLED_ANDROID ${ANDROID}
 
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ADD ./common/install_cache.sh install_cache.sh


### PR DESCRIPTION
This adds vision (OpenCV and ffmpeg), DB (LMDB, LevelDB, and Redis), protobuf, and Android as new docker installable components.

This is a part of getting Caffe2 tests to run on PyTorch docker images and CircleCI as being worked on in https://github.com/pytorch/pytorch/pull/13733 

cc @yf225 @pjh5