### PR TITLE
Remove the AWS apt mirror

### DIFF
--- a/common/install_base.sh
+++ b/common/install_base.sh
@@ -2,13 +2,6 @@
 
 set -ex
 
-# Use AWS mirror if running in EC2
-if [ -n "${EC2:-}" ]; then
-  A="archive.ubuntu.com"
-  B="us-east-1.ec2.archive.ubuntu.com"
-  perl -pi -e "s/${A}/${B}/g" /etc/apt/sources.list
-fi
-
 if [[ "$UBUNTU_VERSION" == "14.04" ]]; then
   # cmake 2 is too old
   cmake3=cmake3

--- a/common/install_db.sh
+++ b/common/install_db.sh
@@ -20,13 +20,6 @@ install_protobuf_26() {
 }
 
 install_ubuntu() {
-  # Use AWS mirror if running in EC2
-  if [ -n "${EC2:-}" ]; then
-    A="archive.ubuntu.com"
-    B="us-east-1.ec2.archive.ubuntu.com"
-    perl -pi -e "s/${A}/${B}/g" /etc/apt/sources.list
-  fi
-
   apt-get update
   apt-get install -y --no-install-recommends \
           libhiredis-dev \

--- a/common/install_protobuf.sh
+++ b/common/install_protobuf.sh
@@ -20,13 +20,6 @@ install_protobuf_26() {
 }
 
 install_ubuntu() {
-  # Use AWS mirror if running in EC2
-  if [ -n "${EC2:-}" ]; then
-    A="archive.ubuntu.com"
-    B="us-east-1.ec2.archive.ubuntu.com"
-    perl -pi -e "s/${A}/${B}/g" /etc/apt/sources.list
-  fi
-
   # Ubuntu 14.04 ships with protobuf 2.5, but ONNX needs protobuf >= 2.6
   # so we install that here if on 14.04
   # Ubuntu 14.04 also has cmake 2.8.12 as the default option, so we will

--- a/common/install_vision.sh
+++ b/common/install_vision.sh
@@ -20,13 +20,6 @@ install_protobuf_26() {
 }
 
 install_ubuntu() {
-  # Use AWS mirror if running in EC2
-  if [ -n "${EC2:-}" ]; then
-    A="archive.ubuntu.com"
-    B="us-east-1.ec2.archive.ubuntu.com"
-    perl -pi -e "s/${A}/${B}/g" /etc/apt/sources.list
-  fi
-
   apt-get update
   apt-get install -y --no-install-recommends \
           libopencv-dev \


### PR DESCRIPTION
Doesn't seem to work now that we're pulling more things from it.

@yf225 @pjh5