### PR TITLE
Add Android NDK docker image for pytorch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -136,6 +136,14 @@ case "$image" in
     DB=yes
     VISION=yes
     ;;
+  pytorch-linux-xenial-py3-clang5-android-ndk-r19c)
+    ANACONDA_PYTHON_VERSION=3.6
+    CLANG_VERSION=5.0
+    PROTOBUF=yes
+    ANDROID=yes
+    ANDROID_NDK_VERSION=r19c
+    CMAKE_VERSION=3.6.3
+    ;;
 esac
 
 # Set Jenkins UID and GID if running Jenkins
@@ -164,6 +172,9 @@ docker build \
        --build-arg "GCC_VERSION=${GCC_VERSION}" \
        --build-arg "CUDA_VERSION=${CUDA_VERSION}" \
        --build-arg "CUDNN_VERSION=${CUDNN_VERSION}" \
+       --build-arg "ANDROID=${ANDROID}" \
+       --build-arg "ANDROID_NDK=${ANDROID_NDK_VERSION}" \
+       --build-arg "CMAKE_VERSION=${CMAKE_VERSION:-}" \
        -f $(dirname ${DOCKERFILE})/Dockerfile \
        -t "$tmp_tag" \
        "$@" \

--- a/common/install_android.sh
+++ b/common/install_android.sh
@@ -2,13 +2,15 @@
 
 set -ex
 
+[ -n "${ANDROID_NDK}" ] || ANDROID_NDK=r13b
+
 apt-get update
 apt-get install -y --no-install-recommends autotools-dev autoconf unzip
 apt-get autoclean && apt-get clean
 rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 pushd /tmp
-curl -Os https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
+curl -Os https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK}-linux-x86_64.zip
 popd
 _ndk_dir=/opt/ndk
 mkdir -p "$_ndk_dir"

--- a/common/install_android.sh
+++ b/common/install_android.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-[ -n "${ANDROID_NDK}" ] || ANDROID_NDK=r13b
+[ -n "${ANDROID_NDK}" ]
 
 apt-get update
 apt-get install -y --no-install-recommends autotools-dev autoconf unzip

--- a/common/install_cmake.sh
+++ b/common/install_cmake.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+[ -n "$CMAKE_VERSION" ]
+
+# Turn 3.6.3 into v3.6
+path=$(echo "${CMAKE_VERSION}" | sed -e 's/\([0-9].[0-9]\+\).*/v\1/')
+file="cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
+
+# Download and install specific CMake version in /usr/local
+pushd /tmp
+curl -Os "https://cmake.org/files/${path}/${file}"
+tar -C /usr/local --strip-components 1 --no-same-owner -zxf cmake-*.tar.gz
+rm -f cmake-*.tar.gz
+popd

--- a/ubuntu-cuda/Dockerfile
+++ b/ubuntu-cuda/Dockerfile
@@ -57,13 +57,6 @@ RUN if [ -n "${VISION}" ]; then bash ./install_vision.sh; fi
 RUN rm install_vision.sh
 ENV INSTALLED_VISION ${VISION}
 
-# (optional) Install Android NDK
-ARG ANDROID
-ADD ./common/install_android.sh install_android.sh
-RUN if [ -n "${ANDROID}" ]; then bash ./install_android.sh; fi
-RUN rm install_android.sh
-ENV INSTALLED_ANDROID ${ANDROID}
-
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ADD ./common/install_cache.sh install_cache.sh
 ENV PATH /opt/cache/bin:$PATH

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -60,10 +60,17 @@ ENV INSTALLED_VISION ${VISION}
 
 # (optional) Install Android NDK
 ARG ANDROID
+ARG ANDROID_NDK
 ADD ./common/install_android.sh install_android.sh
 RUN if [ -n "${ANDROID}" ]; then bash ./install_android.sh; fi
 RUN rm install_android.sh
 ENV INSTALLED_ANDROID ${ANDROID}
+
+# (optional) Install non-default CMake version
+ARG CMAKE_VERSION
+ADD ./common/install_cmake.sh install_cmake.sh
+RUN if [ -n "${CMAKE_VERSION}" ]; then bash ./install_cmake.sh; fi
+RUN rm install_cmake.sh
 
 # Install ccache/sccache (do this last, so we get priority in PATH)
 ADD ./common/install_cache.sh install_cache.sh


### PR DESCRIPTION
Android NDK image is needed to support PyTorch mobile work.
Also need upgrade cmake there as required by the NDK.

Test Plan:
- Verified existing docker images can still be built:
./build.sh pytorch-linux-xenial-py3-clang5-asan

- Verified new Android docker image can be built and can build libcaffe2 Android inside it:
./build.sh pytorch-linux-xenial-py3-clang5-android-ndk-r19c
...
Successfully built ff76dea4c740

docker run -it ff76dea4c740 /bin/bash

git clone --recursive https://github.com/pytorch/pytorch
export ANDROID_NDK=/opt/ndk

// Edit scripts/build_android.sh to remove -DANDROID_TOOLCHAIN=gcc which is not supported by NDK r19
scripts/build_android.sh
