### PR TITLE
Attempt to fix clang 7 version number

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -156,7 +156,7 @@ case "$image" in
     ;;
   pytorch-linux-xenial-py3.6-clang7)
     ANACONDA_PYTHON_VERSION=3.6
-    CLANG_VERSION=7.0
+    CLANG_VERSION=7
     PROTOBUF=yes
     DB=yes
     VISION=yes

--- a/common/install_clang.sh
+++ b/common/install_clang.sh
@@ -4,7 +4,13 @@ set -ex
 
 if [ -n "$CLANG_VERSION" ]; then
 
-  apt-get update
+  if [[ $CLANG_VERSION == 7 && $UBUNTU_VERSION == 16.04 ]]; then
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
+  fi
+
+  sudo apt-get update
+
   apt-get install -y --no-install-recommends clang-"$CLANG_VERSION"
   apt-get install -y --no-install-recommends llvm-"$CLANG_VERSION"
 


### PR DESCRIPTION
Apparently in ubuntu the clang 7 package is called `clang-7` and not `clang-7.0`