### PR TITLE
[android] downgrade gradle to version 4.10.3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -152,7 +152,7 @@ case "$image" in
     PROTOBUF=yes
     ANDROID=yes
     ANDROID_NDK_VERSION=r19c
-    GRADLE_VERSION=5.1.1
+    GRADLE_VERSION=4.10.3
     CMAKE_VERSION=3.6.3
     ;;
   pytorch-linux-xenial-py3.6-clang7)


### PR DESCRIPTION
gradle bintray (publishing artifacts to bintray, snapshots to sonatype) plugin is incompatible with gradle version 5
gradle version 4 works fine